### PR TITLE
Caching

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "jsxBracketSameLine": true
+  "jsxBracketSameLine": true,
+  "trailingComma": "es5"
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The third option is `dedupeOptions`, and it is also optional. This is an object 
 * `dedupe` *(Boolean)*: Whether or not to dedupe the request. Pass `false` and it will be as if this library
   was not even being used. Defaults to `true`.
 
+* `cachePolicy` *(String)*: Determines interactions with the cache. Valid options are `"cache-first"`, `"cache-only"`,
+  and `"network-only"`. For more, refer to the section on Caching.
+
 Given the two possible value types of `input`,  optional second argument, there are a way few ways that you can
 call `fetchDedupe`. Let's run through valid calls to `fetchDedupe`:
 
@@ -205,11 +208,55 @@ const readingBooksAlready = isRequestInFlight(key);
   if you intend to use this method. In other words, _do not_ rely on being able to
   reliably reproduce the request key that is created when a `requestKey` is not passed in.
 
+##### `isResponseCached( requestKey )`
+
+Pass in a `requestKey` to see if there is a cache entry for the request. This can be used
+to determine if a call to `fetchDedupe` will hit the cache or not.
+
+> Now: We **strongly** recommend that you manually pass in `requestKey` to `fetchDedupe`
+  if you intend to use this method. In other words, _do not_ rely on being able to
+  reliably reproduce the request key that is created when a `requestKey` is not passed in.
+
 ##### `clearRequestCache()`
 
 Wipe the cache of in-flight requests.
 
 > Warning: this is **not** safe to use in application code. It is mostly useful for testing.
+
+##### `clearResponseCache()`
+
+Wipe the cache of responses.
+
+> Warning: this is **not** safe to use in application code. It is mostly useful for testing.
+
+### Guides
+
+##### Caching
+
+The way the cache works is like this: any time a response from the server is received, it will be
+cached using the request's request key. Subsequent requests are matched with existing cached server
+responses using their request key.
+
+Interactions with the cache can be controlled with the `cachePolicy` option. There are three possible
+values:
+
+**`cache-first`**
+
+This is the default behavior.
+
+Requests will first look at the cache to see if a response for the same request key exists. If a response is
+found, then it will be returned, and no network request will be made.
+
+If no response exists in the cache, then a network request will be made.
+
+**`network-only`**
+
+The cache is ignored, and a network request is always made.
+
+**`cache-only`**
+
+If a response exists in the cache, then it will be returned. If no response
+exists in the cache, then an error will be passed into the render prop function.
 
 ### FAQ & Troubleshooting
 
@@ -230,7 +277,7 @@ of "write" requests (deletes, updates, and less commonly creates). For this reas
 behavior of `responseType` is `"json"` except in situations when a 204 code is returned, in which
 case `"text"` will be used instead.
 
-If your API returns empty bodies with other codes, then you have two options. The first is to
+If your API returns empty bodies in other situations, then you have two options. The first is to
 pass a function as `responseType`. This lets you specify the `responseType` based on the `response`.
 
 For instance, if your backend returns JSON for successful responses, but text stack traces otherwise,
@@ -264,6 +311,23 @@ know what its content type is.
 
 Just strings for now, which should work for the majority of APIs. Support for other body types
 is in the works.
+
+##### Is the data duplicated?
+
+Although you receive a new `Response` object with every call to `fetch-dedupe`, the body will be read,
+so the response's body stream will be empty. In addition, the `data` property between every
+`response` is shared. Accordingly, the data returned by the server is never duplicated.
+
+This is an optimization that allows `fetch-dedupe` to be used in applications that fetch
+large payloads.
+
+##### `res.bodyUsed` is `false` when the body has already been used
+
+As of Feb 2018, there is a bug in several browsers and `node-fetch`, where the value of `bodyUsed`
+will be `false` when it should, in fact, be `true`.
+
+As a workaround, when using `fetch-dedupe`, the body will always be used by the time you receive
+the Response.
 
 ### Implementors
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,11 @@
-// This is a cache of in-flight requests. Each request key maps to an
-// array of Promises. When the request resolves, each promise in the
-// array is pushed to.
-let requests = {};
+let requestCache = {};
+let responseCache = {};
 
 export function getRequestKey({
   url = '',
   method = '',
   responseType = '',
-  body = ''
+  body = '',
 } = {}) {
   return [url, method.toUpperCase(), responseType, body].join('||');
 }
@@ -15,21 +13,31 @@ export function getRequestKey({
 // Returns `true` if a request with `requestKey` is in flight,
 // and `false` otherwise.
 export function isRequestInFlight(requestKey) {
-  return Boolean(requests[requestKey]);
+  return Boolean(requestCache[requestKey]);
+}
+
+export function isResponseCached(requestKey) {
+  return Boolean(responseCache[requestKey]);
 }
 
 export function clearRequestCache() {
-  requests = {};
+  requestCache = {};
+}
+
+export function clearResponseCache() {
+  responseCache = {};
 }
 
 // This loops through all of the handlers for the request and either
 // resolves or rejects them.
 function resolveRequest({ requestKey, res, err }) {
-  const handlers = requests[requestKey] || [];
+  const handlers = requestCache[requestKey] || [];
 
   handlers.forEach(handler => {
     if (res) {
-      handler.resolve(res);
+      const resToSend = new Response(res.body, res);
+      resToSend.data = res.data;
+      handler.resolve(resToSend);
     } else {
       handler.reject(err);
     }
@@ -37,24 +45,57 @@ function resolveRequest({ requestKey, res, err }) {
 
   // This list of handlers has been, well, handled. So we
   // clear the handlers for the next request.
-  requests[requestKey] = null;
+  requestCache[requestKey] = null;
 }
+
+function CacheMissError() {
+  var err = Error.apply(this, arguments);
+  err.name = this.name = 'CacheMissError';
+  this.message = err.message;
+  this.stack = err.stack;
+}
+
+CacheMissError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: CacheMissError,
+    writable: true,
+    configurable: true,
+  },
+});
 
 export function fetchDedupe(input, init, dedupeOptions) {
   let opts, initToUse;
   if (dedupeOptions) {
     opts = dedupeOptions;
     initToUse = init;
-  } else if (init && init.responseType) {
+  } else if (
+    init &&
+    (init.responseType || init.dedupe || init.cachePolicy || init.requestKey)
+  ) {
     opts = init;
     initToUse = {};
   } else {
     opts = {};
-    initToUse = {};
+    initToUse = init || {};
   }
 
-  const { requestKey, responseType = '', dedupe = true } = opts;
+  const { requestKey, responseType = '', dedupe = true, cachePolicy } = opts;
 
+  const method = initToUse.method || input.method || '';
+  const upperCaseMethod = method.toUpperCase();
+
+  let appliedCachePolicy;
+  if (cachePolicy) {
+    appliedCachePolicy = cachePolicy;
+  } else {
+    const isReadRequest =
+      upperCaseMethod === 'GET' ||
+      upperCaseMethod === 'OPTIONS' ||
+      upperCaseMethod === 'HEAD' ||
+      upperCaseMethod === '';
+
+    appliedCachePolicy = isReadRequest ? 'cache-first' : 'network-only';
+  }
   // Build the default request key if one is not passed
   let requestKeyToUse =
     requestKey ||
@@ -64,16 +105,33 @@ export function fetchDedupe(input, init, dedupeOptions) {
       // We prefer values from `init` over request objects. With `fetch()`, init
       // takes priority over a passed-in request
       method: initToUse.method || input.method || '',
-      body: initToUse.body || input.body || ''
+      body: initToUse.body || input.body || '',
     });
+
+  let cachedResponse;
+  if (appliedCachePolicy !== 'network-only') {
+    cachedResponse = responseCache[requestKeyToUse];
+
+    if (cachedResponse) {
+      var resp = new Response(cachedResponse.body, cachedResponse);
+      resp.data = cachedResponse.data;
+      resp.fromCache = true;
+      return Promise.resolve(resp);
+    } else if (cachePolicy === 'cache-only') {
+      const cacheError = new CacheMissError(
+        `Response for fetch request not found in cache.`
+      );
+      return Promise.reject(cacheError);
+    }
+  }
 
   let proxyReq;
   if (dedupe) {
-    if (!requests[requestKeyToUse]) {
-      requests[requestKeyToUse] = [];
+    if (!requestCache[requestKeyToUse]) {
+      requestCache[requestKeyToUse] = [];
     }
 
-    const handlers = requests[requestKeyToUse];
+    const handlers = requestCache[requestKeyToUse];
     const requestInFlight = Boolean(handlers.length);
     const requestHandler = {};
     proxyReq = new Promise((resolve, reject) => {
@@ -105,6 +163,7 @@ export function fetchDedupe(input, init, dedupeOptions) {
       // the fetch.
       return res[responseTypeToUse]().then(data => {
         res.data = data;
+        responseCache[requestKeyToUse] = res;
 
         if (dedupe) {
           resolveRequest({ requestKey: requestKeyToUse, res });


### PR DESCRIPTION
This supports 3 common caching use cases:

- network-only
- cache-only
- cache-first

---

Because `fetch()` only supports 1 response, I can't add cache-and-network at this level.

Resolves #22 

---

Todo:

- [x] Update documentation
- [x] Add `bodyUsed` caveats to guides
- [x] Add tests
  - [x] cache tests
  - [x] isRequestCached test