### PR TITLE
fix for unresovled 404 requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,13 @@ export function fetchDedupe(input, init, dedupeOptions) {
 
   const request = fetch(input, initToUse).then(
     res => {
+      if (!res.ok) {
+        if (dedupe) {
+          resolveRequest({ requestKey: requestKeyToUse, res });
+        } else {
+          return res;
+        }
+      }
       let responseTypeToUse;
       if (responseType instanceof Function) {
         responseTypeToUse = responseType(res);


### PR DESCRIPTION
    - when the res is 404, resoluveRequest() is never being invoked.
    - this fix should hopefully resolve the request