### PR TITLE
feature: add tdd script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf dist es tmp lib",
     "test": "jest",
-    "test:tdd": "jest --watch",
+    "test:watch": "jest --watch",
     "prepublish": "in-publish && npm run build || not-in-publish",
     "build": "npm run clean && npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:commonjs",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "rimraf dist es tmp lib",
     "test": "jest",
+    "test:tdd": "jest --watch",
     "prepublish": "in-publish && npm run build || not-in-publish",
     "build": "npm run clean && npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:commonjs",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",


### PR DESCRIPTION
I have added a `test:tdd` script to make doing test-driven development easier. It simply adds the `--watch` flag to `jest` which watches your files and re-runs tests when it detects file changes.