### PR TITLE
Handle errors thrown while reading the response body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export function fetchDedupe(input, init = {}, dedupeOptions) {
             return res;
           }
         },
-        error => {
+        () => {
           res.data = null;
 
           if (dedupe) {

--- a/src/index.js
+++ b/src/index.js
@@ -103,15 +103,26 @@ export function fetchDedupe(input, init = {}, dedupeOptions) {
       // The response body is a ReadableStream. ReadableStreams can only be read a single
       // time, so we must handle that in a central location, here, before resolving
       // the fetch.
-      return res[responseTypeToUse]().then(data => {
-        res.data = data;
+      return res[responseTypeToUse]().then(
+        data => {
+          res.data = data;
 
-        if (dedupe) {
-          resolveRequest({ requestKey: requestKeyToUse, res });
-        } else {
-          return res;
+          if (dedupe) {
+            resolveRequest({ requestKey: requestKeyToUse, res });
+          } else {
+            return res;
+          }
+        },
+        error => {
+          res.data = null;
+
+          if (dedupe) {
+            resolveRequest({ requestKey: requestKeyToUse, res });
+          } else {
+            return res;
+          }
         }
-      });
+      );
     },
     err => {
       if (dedupe) {

--- a/test/responses.js
+++ b/test/responses.js
@@ -18,3 +18,10 @@ export function emptyResponse() {
     statusText: 'OK'
   });
 }
+
+export function serverErrorResponse() {
+  return new Response('Server error message', {
+    status: 500,
+    statusText: 'Internal Server Error'
+  });
+}


### PR DESCRIPTION
Solves #39 by adding a rejection handler to the `then` after reading the response body. It will now return the response even if there's an error reading its body.