### PR TITLE
Introduce option to save to cache or not

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ export function bestfetch(input, options) {
     requestKey,
     responseType = '',
     dedupe = true,
+    saveToCache,
     cachePolicy,
     ...init
   } = opts;
@@ -148,8 +149,15 @@ export function bestfetch(input, options) {
       // the fetch.
       return res[responseTypeToUse]().then(
         data => {
+          let willWriteToCache;
+          if (typeof saveToCache === 'boolean') {
+            willWriteToCache = saveToCache;
+          } else {
+            willWriteToCache = shouldWriteCachedValue(res);
+          }
+
           res.data = data;
-          if (shouldWriteCachedValue(res)) {
+          if (willWriteToCache) {
             responseCache.set(requestKeyToUse, res);
           }
 


### PR DESCRIPTION
Resolves #58 

---

Some of my thinking here:

1. it's a separate option because `cachePolicy` is about how to _read_ from the cache, and this is about how to _write_ to the cache.
2. this overrules the `readCachePolicy` on a per-request basis, because the read cache policy is how you configure the _default_ behavior.