### PR TITLE
Rename network-only to reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export function bestfetch(input, options) {
       upperCaseMethod === 'HEAD' ||
       upperCaseMethod === '';
 
-    appliedCachePolicy = isReadRequest ? 'cache-first' : 'network-only';
+    appliedCachePolicy = isReadRequest ? 'cache-first' : 'reload';
   }
 
   const ignoreCacheOnResponse = appliedCachePolicy === 'no-cache';
@@ -102,10 +102,7 @@ export function bestfetch(input, options) {
       body: init.body || '',
     });
 
-  if (
-    appliedCachePolicy !== 'network-only' &&
-    appliedCachePolicy !== 'no-cache'
-  ) {
+  if (appliedCachePolicy !== 'reload' && appliedCachePolicy !== 'no-cache') {
     if (shouldUseCachedValue(requestKeyToUse)) {
       return Promise.resolve(responseCache.get(requestKeyToUse));
     } else if (cachePolicy === 'cache-only') {

--- a/test/bestfetch/cache-policies.test.js
+++ b/test/bestfetch/cache-policies.test.js
@@ -36,7 +36,7 @@ describe('bestfetch: cachePolicy', () => {
     });
   });
 
-  test('network-only ignores the cache', done => {
+  test('reload ignores the cache', done => {
     bestfetch('/test/succeeds/json', { requestKey: 'my-request' }).then(res => {
       expect(res).toEqual(
         expect.objectContaining({
@@ -53,7 +53,7 @@ describe('bestfetch: cachePolicy', () => {
 
       bestfetch('/test/succeeds/json', {
         requestKey: 'my-request',
-        cachePolicy: 'network-only',
+        cachePolicy: 'reload',
       }).then(res => {
         expect(res).toEqual(
           expect.objectContaining({
@@ -127,7 +127,7 @@ describe('bestfetch: cachePolicy', () => {
     });
   });
 
-  test('default for "write" requests is network-only', done => {
+  test('default for "write" requests is reload', done => {
     bestfetch('/test/succeeds/json', {
       requestKey: 'my-request',
       method: 'POST',


### PR DESCRIPTION
This comes from the value list of `fetch`'s [cache](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) option.

The problem with `"network-only"` is that it can be interpreted as being identical to `"no-cache"`, when it's not.

Think of like this: you're "reloading" the value in the cache when you make this request.